### PR TITLE
fix: handle divide-by-zero with ValueError (#1)

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -6,7 +6,8 @@ def add(a: int, b: int) -> int:
 
 
 def divide(a: int, b: int) -> float:
-    # Bug: no zero division check
+    if b == 0:
+        raise ValueError("Cannot divide by zero")
     return a / b
 
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,4 +1,5 @@
-from src.calculator import add, multiply
+import pytest
+from src.calculator import add, divide, multiply
 
 
 def test_add():
@@ -11,3 +12,12 @@ def test_add_negative():
 
 def test_multiply():
     assert multiply(3, 4) == 12
+
+
+def test_divide():
+    assert divide(10, 2) == 5.0
+
+
+def test_divide_zero_raises_value_error():
+    with pytest.raises(ValueError, match="Cannot divide by zero"):
+        divide(10, 0)


### PR DESCRIPTION
## Root Cause
`divide()` in `src/calculator.py` had no zero-division check — raised unhandled `ZeroDivisionError`.

## Fix
Added validation: `if b == 0: raise ValueError("Cannot divide by zero")`

## Testing
- `test_divide()` — normal division
- `test_divide_zero_raises_value_error()` — zero case

All 5 tests pass.

Closes #1

🤖 Generated by DevLoop (AI agent-based development loop)